### PR TITLE
fix: declare the LFS endpoint so shallow clones fetch real binaries

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,14 @@
+# Tells the Git LFS client where this repo's LFS server is, without relying on
+# it being inferred from the clone's remote.
+#
+# Unity's Package Manager shallow-clones git dependencies, and its own docs note
+# that LFS-tracked files "aren't always fetched correctly" as a result — the
+# package can import placeholder pointer files instead of the real contents.
+# That is exactly what happened here: consumers got a 134-byte pointer where
+# FirebaseCppApp-*.bundle should be, and Unity failed to load it with
+# "slice is not valid mach-o file". Reproduced identically on two machines,
+# unaffected by `git lfs install` or by clearing every Unity cache.
+#
+# An explicit endpoint is Unity's recommended mitigation for package authors.
+[lfs]
+    url = https://github.com/Cosmic-Pulse/com.google.firebase.app.git/info/lfs


### PR DESCRIPTION
Consumers of this package via UPM get a **134-byte pointer file** where `Firebase/Plugins/x86_64/FirebaseCppApp-13_1_0.bundle` should be a 14 MB binary. Unity then fails to load it:

```
DllNotFoundException: dlopen(.../FirebaseCppApp-13_1_0.bundle, 0x0002):
  tried: '.../FirebaseCppApp-13_1_0.bundle' (slice is not valid mach-o file)
```

which throws in `Firebase.AppUtilPINVOKE`'s static initialiser and puts an error in the console on every boot.

### Why

[Unity's docs](https://docs.unity3d.com/Manual/upm-git.html) say it directly:

> The Package Manager supports Git dependencies from repositories that use Git LFS. However, because Unity uses **shallow clones**, LFS-tracked files aren't always fetched correctly... the package might import **placeholder pointer files** instead of the actual file contents.

This repo LFS-tracks `*.bundle` and `*.so` but declares no LFS endpoint, so the client has nothing to fall back on during a shallow clone. Adding `.lfsconfig` is Unity's recommended mitigation for package authors.

### What ruled everything else out

Reproduced identically on two different runners, and unaffected by `git lfs install` on the host or by clearing every Unity package cache. Identical behaviour across differently-configured machines pointed at the clone rather than the host. The repo is public, so the auth clause in Unity's docs doesn't apply either.

### Caveat

Unity says LFS files "aren't **always** fetched correctly" — this improves the odds, it doesn't guarantee them. If pointers still appear, the robust fix is to stop LFS-tracking these binaries here at all: the repo is 191 MB and its `.dll` is already plain-committed at 14.7 MB, so only `*.bundle` and `*.so` are affected, by a `.gitattributes` that looks inherited rather than chosen.